### PR TITLE
refac: Change error handling and pass individual categories in as props

### DIFF
--- a/src/apiCalls.js
+++ b/src/apiCalls.js
@@ -1,7 +1,12 @@
 export const getAllMovies = () => {
   return fetch('https://rancid-tomatillos.herokuapp.com/api/v2/movies')
-    .then(response => response.json())
-    .then(data => data.movies);
+  .then(response => {
+    if (response.ok) {
+      return response.json();
+    } else {
+      throw new Error(response.statusText);
+    }
+  })
 };
 
 export const getMovieById = (id) => {
@@ -10,8 +15,7 @@ export const getMovieById = (id) => {
       if (response.ok) {
         return response.json();
       } else {
-        throw new Error('Movie not found.');
+        throw new Error(response.statusText);
       }
     })
-    .then(data => data.movie);
 };

--- a/src/components/App/App.css
+++ b/src/components/App/App.css
@@ -1,0 +1,5 @@
+.error {
+  background-color: red;
+  color: white;
+  font-size: 1.2rem;
+}

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -12,36 +12,44 @@ class App extends Component {
     this.state = {
       allMovies: [],
       selectedMovie: null,
-      error: null
+      error: null,
     }
   }
 
   componentDidMount = () => {
-    getAllMovies().then(movies => {
-      this.setState({ allMovies: movies });
-    });
+    getAllMovies()
+      .then(movies => { this.setState({ allMovies: movies.movies })})
+      .catch(error => {this.setState({ error: error.toString() })});
   }
 
   chooseMovie = (movie) => {
     if (movie) {
-      getMovieById(movie.id).then(movieData => {
-        this.setState({ selectedMovie: movieData });
-      }).catch(error => {
-        this.setState({ error: error.message });
-      });
+      getMovieById(movie.id)
+        .then(movieData => {this.setState({ selectedMovie: movieData.movie })})
+        .catch(error => {this.setState({ error: error.toString() })});
     } else {
       this.setState({ selectedMovie: null });
     }
   }
 
-
   render() {
     return (
       <div className="App">
         <Header />
-        {this.state.error && <p className="error">{this.state.error}</p>}
-        {!this.state.selectedMovie && <MoviesList allMovies={this.state.allMovies} chooseMovie={this.chooseMovie} />}
-        {this.state.selectedMovie && <MovieDetails selectedMovie={this.state.selectedMovie} chooseMovie={this.chooseMovie} />}
+        {this.state.error && <p className="error">Sorry, there was an error loading your page!  {this.state.error}</p>}
+        {!this.state.selectedMovie && !this.state.error && <MoviesList allMovies={this.state.allMovies} chooseMovie={this.chooseMovie} />}
+        {this.state.selectedMovie && !this.state.error && <MovieDetails 
+          title={this.state.selectedMovie.title}
+          average_rating={this.state.selectedMovie.average_rating}
+          overview= {this.state.selectedMovie.overview}
+          genres={this.state.selectedMovie.genres}
+          budget={this.state.selectedMovie.budget}
+          revenue={this.state.selectedMovie.revenue}
+          runtime={this.state.selectedMovie.runtime}
+          tagline={this.state.selectedMovie.tagline}
+          backdrop_path={this.state.selectedMovie.backdrop_path}
+          poster_path={this.state.selectedMovie.poster_path}
+          chooseMovie={this.chooseMovie} />}
       </div>
     )
   };

--- a/src/components/MovieDetails/MovieDetails.js
+++ b/src/components/MovieDetails/MovieDetails.js
@@ -2,21 +2,21 @@ import "./MovieDetails.css";
 import Footer from "./Footer/Footer";
 import PropTypes from 'prop-types';
 
-const MovieDetails = ({selectedMovie, chooseMovie}) => {
+const MovieDetails = ({title, average_rating, overview, genres, budget, revenue, runtime, tagline, backdrop_path, poster_path, chooseMovie}) => {
   return (
     <div className="overlay-single-movie">
-      <img src={selectedMovie.backdrop_path} className="backdrop"/>
+      <img src={backdrop_path} className="backdrop"/>
       <div className="movie-info">
-        <img src={selectedMovie.poster_path} className="movie-poster" />
+        <img src={poster_path} className="movie-poster" />
         <div className="details">
-          <h2>{selectedMovie.title} - {Math.round(selectedMovie.average_rating)}/10</h2>
+          <h2>{title} - {Math.round(average_rating)}/10</h2>
           <ul>
-            {selectedMovie.overview ? <li><span className="category">Overview:</span> {selectedMovie.overview}</li> : null}
-            {selectedMovie.genres ? <li><span className="category">Genres:</span> {selectedMovie.genres.map((genre, index) => index ? ", " + genre : genre)}</li>: null}
-            {selectedMovie.budget ? <li><span className="category">Budget:</span> ${selectedMovie.budget.toLocaleString()}</li>: null}
-            {selectedMovie.revenue ? <li><span className="category">Revenue:</span> ${selectedMovie.revenue.toLocaleString()}</li>: null}
-            {selectedMovie.runtime ? <li><span className="category">Runtime:</span> {selectedMovie.runtime} minutes</li>: null}
-            {selectedMovie.tagline ? <li><span className="category">Tagline:</span> {selectedMovie.tagline}</li>: null}
+            {overview && <li><span className="category">Overview:</span> {overview}</li>}
+            {genres && <li><span className="category">Genres:</span> {genres.map((genre, index) => index ? ", " + genre : genre)}</li>}
+            {budget ? <li><span className="category">Budget:</span> ${budget.toLocaleString()}</li>: null}
+            {revenue ? <li><span className="category">Revenue:</span> ${revenue.toLocaleString()}</li>: null}
+            {runtime ? <li><span className="category">Runtime:</span> {runtime} minutes</li>: null}
+            {tagline && <li><span className="category">Tagline:</span> {tagline}</li>}
           </ul>
         </div>
       </div>
@@ -28,16 +28,14 @@ const MovieDetails = ({selectedMovie, chooseMovie}) => {
 export default MovieDetails;
 
 MovieDetails.propTypes = {
-  selectedMovie: PropTypes.shape({
-    backdrop_path: PropTypes.string.isRequired,
-    title: PropTypes.string.isRequired,
-    average_rating: PropTypes.number.isRequired,
-    overview: PropTypes.string,
-    genres: PropTypes.arrayOf(PropTypes.string),
-    budget: PropTypes.number,
-    revenue: PropTypes.number,
-    runtime: PropTypes.number,
-    tagline: PropTypes.string,
-  }).isRequired,
+  backdrop_path: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  average_rating: PropTypes.number.isRequired,
+  overview: PropTypes.string,
+  genres: PropTypes.arrayOf(PropTypes.string),
+  budget: PropTypes.number,
+  revenue: PropTypes.number,
+  runtime: PropTypes.number,
+  tagline: PropTypes.string,
   chooseMovie: PropTypes.func.isRequired
 }


### PR DESCRIPTION
PR TEMPLATE:
# Description
This was a refactor of error handling for fetch calls.  We also decided that instead of passing in an entire object with key/value pairs as a prop, we would pass each key/value as its own individual prop.  

**Requesting review on**:  inside App.js, in the render() on lines 42-52, is it better to have each one of those key values passed in individually, or should the movie object be passed in as one whole thing and then each key/value pair be referenced in the child component?  Is there a best practice or is it up to the developer?  We are also considering a refactor where we access the Object.keys of the movie object and map through the keys to create each prop instead of manually writing each one out, but we haven't found a way to do that yet. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring
# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [X] local host
- [X] dev tools
- [X] terminal
# Checklist:
- [X] My code follows the Turing's guidelines of this project
- [X] I have performed a self-review of my own code
- [X] No console error messages